### PR TITLE
Update npm ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,9 @@ src
 test
 node_modules
 webpack.config.js
+.idea
+.github
+.prettierignore
+.prettierrc
+.stylelintrc.json
+tsconfig.json

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gowiz searchbar ![GitHub license](https://img.shields.io/badge/license-UNLICENSED-blue.svg)[![Actions Status](https://github.com/gowizz/SearchBar/workflows/Searchbar%20CI/badge.svg)](https://github.com/gowizz/SearchBar/actions)[![GitHub issues](https://img.shields.io/github/issues/gowizz/Searchbar.svg)](https://github.com/gowizz/SearchBar/issues/)[![npm version](https://badge.fury.io/js/%40gowiz%2Fsearchbar.svg)](https://badge.fury.io/js/%40gowiz%2Fsearchbar)
+# Gowiz searchbar ![GitHub license](https://img.shields.io/badge/license-UNLICENSED-blue.svg)[![Actions Status](https://github.com/gowizz/SearchBar/workflows/Searchbar%20CI/badge.svg)](https://github.com/gowizz/SearchBar/actions)[![npm version](https://badge.fury.io/js/%40gowiz%2Fsearchbar.svg)](https://badge.fury.io/js/%40gowiz%2Fsearchbar)
 
 Gowiz search bars are highly customisable powerful components that can enhance your page experience and that respect the privacy of your users.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1085,9 +1085,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.5",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.5.tgz",
-      "integrity": "sha512-heU+7w8snfwfjtcj2H458aTx3m5unIToOJhx75ebHilBiiQ39OIdA18WkG4LP08YKeAoWAGvWg8s+22w/PeJ6w==",
+      "version": "26.0.7",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.7.tgz",
+      "integrity": "sha512-+x0077/LoN6MjqBcVOe1y9dpryWnfDZ+Xfo3EqGeBcfPRJlQp3Lw62RvNlWxuGv7kOEwlHriAa54updi3Jvvwg==",
       "dev": true,
       "requires": {
         "jest-diff": "^25.2.1",
@@ -1107,9 +1107,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.0.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.24.tgz",
-      "integrity": "sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==",
+      "version": "14.0.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.25.tgz",
+      "integrity": "sha512-okMqUHqrMlGOxfDZliX1yFX5MV6qcd5PpRz96XYtjkM0Ws/hwg23FMUqt6pETrVRZS+EKUB5HY19mmo54EuQbA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -3038,9 +3038,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.505",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.505.tgz",
-      "integrity": "sha512-Aunrp3HWtmdiJLIl+IPSFtEvJ/4Q9a3eKaxmzCthaZF1gbTbpHUTCU2zOVnFPH7r/AD7zQXyuFidYXzSHXBdsw==",
+      "version": "1.3.506",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.506.tgz",
+      "integrity": "sha512-k0PHtv4gD6KJu1k6lp8pvQOe12uZriOwS2x66Vnxkq0NOBucsNrItOj/ehomvcZ3S4K1ueqUCv+fsLhXBs6Zyw==",
       "dev": true
     },
     "elliptic": {
@@ -7052,9 +7052,9 @@
       }
     },
     "parse-json": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-      "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+      "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",


### PR DESCRIPTION
NPM package should publish as few packages as possible, to reduce the file size and to increase security.
This PR prevents NPm from publishing IDEA, .ighub, and config files. Now only package.json and README.md is published.